### PR TITLE
Removes erroneous slash in endpoint to fetch a contact's households

### DIFF
--- a/source/includes/api/v3/_contacts.md
+++ b/source/includes/api/v3/_contacts.md
@@ -417,7 +417,7 @@ id | true | The id of the contact to be retrieved.
 > Example Request
 
 ```http
-GET /v2/contacts/e5554be7-0b3c-45cf-9c78-266dc45e2878/households/ HTTP/1.1
+GET /v2/contacts/e5554be7-0b3c-45cf-9c78-266dc45e2878/households HTTP/1.1
 Host: api.beta.polisapp.com
 Content-Type: application/json
 Authorization: Bearer {access_token}
@@ -505,7 +505,7 @@ Authorization: Bearer {access_token}
 
 ### HTTP Request
 
-`GET https://api.beta.polisapp.com/v2/contacts/{contactId}/households/`
+`GET https://api.beta.polisapp.com/v2/contacts/{contactId}/households`
 
 ### Query Parameters
 


### PR DESCRIPTION
## Description 
Removes erroneous trailing slash in endpoint to get a contact's households. The endpoint is currently `contacts/{contactId}/households/` but it should be `contacts/{contactId}/households`

## Workflow tests

- Grab a contactId from stage.
- Make a postman request to `contacts/{contactId}/households/`. It should return a 404
- Make a postman request to `contacts/{contactId}/households`. It should return the contact's households. 

## Issues 

Hyperlink any issues related to this PR by replacing issue-number with the issue number.

PolisPolitics/HQ#2997


