### PR TITLE
Update campaign misspell

### DIFF
--- a/source/includes/api/v3/_campaigns.md
+++ b/source/includes/api/v3/_campaigns.md
@@ -936,7 +936,7 @@ campaignId | true | The identifier of a campaign.
 contactId | true | The identifier of a contact.
 householdId | true | The identifier of a household.
 
-## Update or Create new Contact Household Campaing records in bulk
+## Update or Create new Contact Household Campaign records in bulk
 
 > Example Request
 


### PR DESCRIPTION
## Description 

Fixed campaign misspell.

## Workflow tests

Check if campaign is now spelled correctly.

## Issues 

[Campaign is misspelled as Campaing in our source code and API docs](https://app.clubhouse.io/knoq/story/269/campaign-is-misspelled-as-campaing-in-our-source-code-and-api-docs)